### PR TITLE
ci: add guardrails — test, lint, vet, and build jobs

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,7 +1,4 @@
-# This workflow will build a golang project
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
-
-name: Generate Release Artifacts
+name: CI
 
 on:
   push:
@@ -9,28 +6,59 @@ on:
     tags: ['v*']
   pull_request:
     branches: [ "main" ]
-    tags: ['v*']
 
 jobs:
-  build:
+  test:
+    name: test
     runs-on: ubuntu-latest
     steps:
-      - name: Check Out Repository
-        uses: actions/checkout@v3
-      - name: Set up Go
-        uses: actions/setup-go@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: '1.21.x'
+      - name: Vet
+        run: go vet ./...
+      - name: Test
+        run: go test ./...
 
-      - name: Build Current Annualized Return
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.21.x'
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.64
+
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.21.x'
+      - name: Build batchStocks
         uses: psethwick/go-cross-build@1.2.0
         with:
           platforms: 'linux/amd64, darwin/amd64, windows/amd64'
-          package: 'cmd/currentReturn'
-          name: 'currentreturn'
+          package: 'cmd/batchStocks'
+          name: 'stockbatch'
           compress: 'true'
           dest: 'bin'
-      - name: Build Stock Client
+      - name: Build filterJSON
+        uses: psethwick/go-cross-build@1.2.0
+        with:
+          platforms: 'linux/amd64, darwin/amd64, windows/amd64'
+          package: 'cmd/filterJSON'
+          name: 'filterjson'
+          compress: 'true'
+          dest: 'bin'
+      - name: Build stockClient
         uses: psethwick/go-cross-build@1.2.0
         with:
           platforms: 'linux/amd64, darwin/amd64, windows/amd64'
@@ -38,7 +66,15 @@ jobs:
           name: 'stockclient'
           compress: 'true'
           dest: 'bin'
-      - name: Build Target Annualized Returns
+      - name: Build currentReturn
+        uses: psethwick/go-cross-build@1.2.0
+        with:
+          platforms: 'linux/amd64, darwin/amd64, windows/amd64'
+          package: 'cmd/currentReturn'
+          name: 'currentreturn'
+          compress: 'true'
+          dest: 'bin'
+      - name: Build targetReturn
         uses: psethwick/go-cross-build@1.2.0
         with:
           platforms: 'linux/amd64, darwin/amd64, windows/amd64'
@@ -46,12 +82,10 @@ jobs:
           name: 'targetreturn'
           compress: 'true'
           dest: 'bin'
-      # Upload Build Files
-      - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v4.3.0
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
         with:
           name: portfoliotools
-          warn: "No file found at bin/*.tar.gz"
           path: bin/*.tar.gz
           compression-level: 6
           overwrite: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,22 @@
+run:
+  timeout: 5m
+
+linters:
+  enable:
+    - govet
+    - gofmt
+    - gosimple
+    - ineffassign
+    - staticcheck
+    - unused
+  # errcheck disabled until error handling refactor is complete (issue #7)
+  disable:
+    - errcheck
+
+issues:
+  exclude-rules:
+    # testClient is a debug tool; exclude from strict linting
+    - path: cmd/testClient
+      linters:
+        - staticcheck
+        - unused

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ release:
 	tar czvf bin/portfoliotools.linux-arm64.tar.gz bin/currentreturn-linux-arm64 bin/stockclient-linux-arm64 bin/targetreturn-linux-arm64
 
 test:
+	go vet ./...
 	go test -v ./pkg/
 
 clean:

--- a/cmd/batchStocks/batchStocks.go
+++ b/cmd/batchStocks/batchStocks.go
@@ -51,7 +51,7 @@ func init() {
 func main() {
 	flag.Parse()
 	var (
-		tickerData          = make(map[string]map[int64]pkg.SingleStockCandle)
+		tickerData          map[string]map[int64]pkg.SingleStockCandle
 		tickerBatch         = make(map[string]map[int64]pkg.SingleStockCandle)
 		batchStockRanges    = make(map[string]pkg.CondensedRangesJSON)
 		tickerArray         = make([]string, 0)
@@ -70,10 +70,10 @@ func main() {
 	}
 
 	configFile, err := os.Open(tickerConfig)
-	defer configFile.Close()
 	if err != nil {
 		log.Printf("error opening the config file: %v", err)
 	}
+	defer configFile.Close()
 	configDecoder := json.NewDecoder(configFile)
 	stockDataConfig := pkg.StockDataConf{}
 	err = configDecoder.Decode(&stockDataConfig)
@@ -104,9 +104,7 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
-		for _, ticker := range row {
-			tickerArray = append(tickerArray, ticker)
-		}
+		tickerArray = append(tickerArray, row...)
 	}
 
 	for _, tickerItem := range tickerArray {
@@ -165,7 +163,7 @@ func main() {
 		for ticker, stock := range tickerData {
 			latestDate := int64(0)
 			var rrHigh, rrLow, rvolpct, avgvolratio float64
-			for date, _ := range tickerData[ticker] {
+			for date := range tickerData[ticker] {
 				// Looking for the "max" date to get the most recent datetime
 				if date > latestDate {
 					latestDate = date
@@ -243,5 +241,4 @@ func main() {
 			log.Fatal(err)
 		}
 	}
-	return
 }

--- a/cmd/batchStocks/batchStocks.go
+++ b/cmd/batchStocks/batchStocks.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"flag"
-	"fmt"
 	"io"
 	"log"
 	"os"
@@ -63,23 +62,23 @@ func main() {
 	// Section parses the config file location, opens it, decodes the JSON and loads the API creds
 	userDir, err = os.UserHomeDir()
 	if err != nil {
-		_ = fmt.Errorf("error reading user's homedir: %w", err)
+		log.Printf("error reading user's homedir: %v", err)
 	}
 	tickerConfig = strings.Replace(tickerConfig, "~", userDir, 1)
 	if _, err = os.Stat(tickerConfig); errors.Is(err, os.ErrNotExist) {
-		_ = fmt.Errorf("error: config file %s does not exist. exiting", tickerConfig)
+		log.Printf("error: config file %s does not exist. exiting", tickerConfig)
 	}
 
 	configFile, err := os.Open(tickerConfig)
 	defer configFile.Close()
 	if err != nil {
-		_ = fmt.Errorf("error opening the config file. %w", err)
+		log.Printf("error opening the config file: %v", err)
 	}
 	configDecoder := json.NewDecoder(configFile)
 	stockDataConfig := pkg.StockDataConf{}
 	err = configDecoder.Decode(&stockDataConfig)
 	if err != nil {
-		_ = fmt.Errorf("error decoding the json config file. exiting. error msg: %w", err)
+		log.Printf("error decoding the json config file: %v", err)
 		os.Exit(1)
 	}
 
@@ -138,7 +137,7 @@ func main() {
 		} else {
 			tickerData, err = pkg.GetStockPrices(strings.ToUpper(tickerItem), stockDataConfig.PolygonAPIToken, resolution, startDateMilli, endDate)
 			if err != nil {
-				_ = fmt.Errorf("unable to get stock prices")
+				log.Printf("unable to get stock prices for %s", strings.ToUpper(tickerItem))
 			}
 		}
 

--- a/cmd/filterJSON/filterJSON.go
+++ b/cmd/filterJSON/filterJSON.go
@@ -4,7 +4,6 @@ import (
 	"cmd/pkg"
 	"encoding/json"
 	"flag"
-	"fmt"
 	"log"
 	"os"
 	"strings"
@@ -28,7 +27,7 @@ func main() {
 	flag.Parse()
 	userDir, err := os.UserHomeDir()
 	if err != nil {
-		_ = fmt.Errorf("error reading user's homedir: %w", err)
+		log.Printf("error reading user's homedir: %v", err)
 	}
 	userDir = strings.Replace(userDir, "~", userDir, 1)
 	readFile, err := os.ReadFile(inFile)

--- a/cmd/filterJSON/filterJSON.go
+++ b/cmd/filterJSON/filterJSON.go
@@ -25,11 +25,10 @@ func main() {
 		data = map[string]pkg.CondensedRangesJSON{}
 	)
 	flag.Parse()
-	userDir, err := os.UserHomeDir()
+	_, err := os.UserHomeDir()
 	if err != nil {
 		log.Printf("error reading user's homedir: %v", err)
 	}
-	userDir = strings.Replace(userDir, "~", userDir, 1)
 	readFile, err := os.ReadFile(inFile)
 	if err != nil {
 		log.Fatal(err)
@@ -47,5 +46,4 @@ func main() {
 		}
 		log.Printf("%s:\n%s\n", ticker, jsonData)
 	}
-	return
 }

--- a/cmd/stockClient/stockClient.go
+++ b/cmd/stockClient/stockClient.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"log"
 	"os"
 	"strings"
 	"time"
@@ -62,33 +63,33 @@ func main() {
 	// Section parses the config file location, opens it, decodes the JSON and loads the API creds
 	userDir, err = os.UserHomeDir()
 	if err != nil {
-		_ = fmt.Errorf("error reading user's homedir: %w", err)
+		log.Printf("error reading user's homedir: %v", err)
 	}
 	tickerConfig = strings.Replace(tickerConfig, "~", userDir, 1)
 	if _, err = os.Stat(tickerConfig); errors.Is(err, os.ErrNotExist) {
-		_ = fmt.Errorf("error: config file %s does not exist. exiting", tickerConfig)
+		log.Printf("error: config file %s does not exist. exiting", tickerConfig)
 	}
 	configFile, err := os.Open(tickerConfig)
 	if err != nil {
-		_ = fmt.Errorf("error opening the config file. %w", err)
+		log.Printf("error opening the config file: %v", err)
 	}
 	defer configFile.Close()
 	configDecoder := json.NewDecoder(configFile)
 	stockDataConfig := pkg.StockDataConf{}
 	err = configDecoder.Decode(&stockDataConfig)
 	if err != nil {
-		_ = fmt.Errorf("error decoding the json config file. exiting. error msg: %w", err)
+		log.Printf("error decoding the json config file: %v", err)
 		os.Exit(1)
 	}
 
 	startTimeMilli, err := time.Parse(time.RFC3339, startTime)
 	if err != nil {
-		_ = fmt.Errorf("Unable to convert startTime to milliseconds.\nstartTime: %s\n", startTime)
+		log.Printf("unable to convert startTime to milliseconds. startTime: %s", startTime)
 		os.Exit(1)
 	}
 	endTimeMilli, err := time.Parse(time.RFC3339, endTime)
 	if err != nil {
-		_ = fmt.Errorf("Unable to convert endTime to milliseconds.\n")
+		log.Printf("unable to convert endTime to milliseconds")
 		os.Exit(1)
 	}
 	// retrieve stock ticker's prices and store in a map
@@ -110,7 +111,7 @@ func main() {
 		}
 		tickerData, err = pkg.GetStockPricesAlpaca(stockDataConfig, strings.ToUpper(ticker), resolution, startTimeMilli, endTimeMilli, debug)
 		if err != nil {
-			fmt.Errorf("unable to retrieve stock data: %e", err)
+			log.Printf("unable to retrieve stock data: %v", err)
 		}
 		if strings.HasPrefix(strings.ToUpper(ticker), "X:") {
 			ticker = strings.Split(ticker, ":")[1]
@@ -119,7 +120,7 @@ func main() {
 	} else {
 		tickerData, err = pkg.GetStockPrices(strings.ToUpper(ticker), stockDataConfig.PolygonAPIToken, resolution, startTimeMilli, endTimeMilli)
 		if err != nil {
-			fmt.Errorf("unable to get stock prices")
+			log.Printf("unable to get stock prices")
 		}
 	}
 
@@ -136,7 +137,7 @@ func main() {
 	//tickerData = pkg.GetLinearRegressionSlope(tickerData, debug)
 
 	if err != nil {
-		fmt.Errorf("error occurred: %w", err)
+		log.Printf("error occurred: %v", err)
 	}
 	pkg.PrintData(tickerData, debug)
 }

--- a/cmd/testClient/testClient.go
+++ b/cmd/testClient/testClient.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"log"
 	"os"
 	"strings"
 	"time"
@@ -43,22 +44,22 @@ func main() {
 	// Section parses the config file location, opens it, decodes the JSON and loads the API creds
 	userDir, err = os.UserHomeDir()
 	if err != nil {
-		fmt.Errorf("error reading user's homedir: %w", err) //nolint:govet
+		log.Printf("error reading user's homedir: %v", err)
 	}
 	tickerConfig = strings.Replace(tickerConfig, "~", userDir, 1)
 	if _, err = os.Stat(tickerConfig); errors.Is(err, os.ErrNotExist) {
-		fmt.Errorf("error: config file %s does not exist. exiting", tickerConfig) //nolint:govet
+		log.Printf("error: config file %s does not exist. exiting", tickerConfig)
 	}
 	configFile, err := os.Open(tickerConfig)
 	if err != nil {
-		fmt.Errorf("error opening the config file. %w", err) //nolint:govet
+		log.Printf("error opening the config file: %v", err)
 	}
 	defer configFile.Close()
 	configDecoder := json.NewDecoder(configFile)
 	stockDataConfig := pkg.StockDataConf{}
 	err = configDecoder.Decode(&stockDataConfig)
 	if err != nil {
-		fmt.Errorf("error decoding the json config file. exiting. error msg: %w", err) //nolint:govet
+		log.Printf("error decoding the json config file: %v", err)
 	}
 
 	startTimeMilli, err := time.Parse(time.RFC3339, startTime)
@@ -71,13 +72,13 @@ func main() {
 		fmt.Printf("Unable to convert endTime to milliseconds.\n")
 		return
 	}
-	stockData, err := pkg.GetStockPricesAlpaca(stockDataConfig, ticker, resolution, startTimeMilli, endTimeMilli)
+	stockData, err := pkg.GetStockPricesAlpaca(stockDataConfig, ticker, resolution, startTimeMilli, endTimeMilli, false)
 	if err != nil {
-		fmt.Errorf("unable to retrieve stock data: %e", err)
+		log.Printf("unable to retrieve stock data: %v", err)
 	}
 	stockDataJSON, jsonErr := json.MarshalIndent(stockData, "", "  ")
 	if jsonErr != nil {
-		fmt.Errorf("unable to marshal JSON: %e", jsonErr)
+		log.Printf("unable to marshal JSON: %v", jsonErr)
 	}
 	fmt.Printf("%s\n", stockDataJSON)
 }

--- a/pkg/TechAnalysis.go
+++ b/pkg/TechAnalysis.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/alpacahq/alpaca-trade-api-go/v3/alpaca"
 	polygon "github.com/polygon-io/client-go/rest"
 	"github.com/polygon-io/client-go/rest/models"
 	gonum "gonum.org/v1/gonum/stat"
@@ -163,22 +162,6 @@ func GetTargetAnnualReturn(costBasis, riskFreeRate float64, purchaseDate time.Ti
 		targetAnnualReturnPrice = 2*costBasis - baseReturn
 	}
 	return targetAnnualReturnPrice, nil
-}
-
-func createAlpacaClient(APIKey, APISecretKey string, live bool) (client *alpaca.Client) {
-	if live {
-		return alpaca.NewClient(alpaca.ClientOpts{
-			APIKey:    APIKey,
-			APISecret: APISecretKey,
-			BaseURL:   ALPACA_LIVE_API,
-		})
-	} else {
-		return alpaca.NewClient(alpaca.ClientOpts{
-			APIKey:    APIKey,
-			APISecret: APISecretKey,
-			BaseURL:   ALPACA_PAPER_API,
-		})
-	}
 }
 
 // GetStockPricesAlpaca retrieves stock prices using Alpaca's stock API. It does NOT gather crypto data using the stock
@@ -366,15 +349,6 @@ func calculateVariance(returns []float64) float64 {
 }
 
 // calculateMean calculates the arithmetic mean of a float64 slice of inputs and returns the resulting mean
-func calculateMean(returns []float64) float64 {
-	var sum float64
-
-	for _, r := range returns {
-		sum += r
-	}
-
-	return sum / float64(len(returns))
-}
 
 /*
 RealizedVolatility calculates the volatility of prices on varying timelines. It's used to calculate the volatility
@@ -871,7 +845,8 @@ func calcLinearRegression(xValues, yValues []float64) (slope, intercept float64,
 // GetSimpleSlopes computes the raw price delta for each duration per day.
 // For each day it looks back N calendar days, rolling back one day at a time
 // until finding a trading day at or before the target, then computes:
-//   slope = close_today - close_at_lookback_date
+//
+//	slope = close_today - close_at_lookback_date
 //
 // SlopeXxxValid is set true only when a lookback date was found; false means
 // insufficient history and the slope value of 0.0 is meaningless.

--- a/pkg/TechAnalysis.go
+++ b/pkg/TechAnalysis.go
@@ -42,7 +42,7 @@ func PrintData(stockPrices map[string]map[int64]SingleStockCandle, debug bool) {
 		jsonTickerData, err = json.MarshalIndent(condensedPrices, "", "  ")
 	}
 	if err != nil {
-		_ = fmt.Errorf("error marshalling data into JSON string")
+		log.Printf("error marshalling data into JSON string: %v", err)
 		os.Exit(1)
 	}
 	fmt.Printf("%v\n", string(jsonTickerData))
@@ -202,7 +202,6 @@ func GetStockPricesAlpaca(clientConfs StockDataConf, ticker, resolution string, 
 	case "1T", "1H", "1D", "1W", "1M":
 		break
 	default:
-		fmt.Errorf("invalid resolution format")
 		err = errors.New("invalid time resolution format error")
 		return nil, err
 	}
@@ -224,7 +223,7 @@ func GetStockPricesAlpaca(clientConfs StockDataConf, ticker, resolution string, 
 
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {
-		fmt.Errorf("error retrieving historical stock bars: %e", err)
+		log.Printf("error retrieving historical stock bars: %v", err)
 	}
 
 	defer res.Body.Close()
@@ -232,7 +231,7 @@ func GetStockPricesAlpaca(clientConfs StockDataConf, ticker, resolution string, 
 
 	err = json.Unmarshal(body, &result)
 	if err != nil {
-		fmt.Errorf("error unmarshalling stock data: %e", err)
+		log.Printf("error unmarshalling stock data: %v", err)
 	}
 
 	stockPrices, ok := result["bars"].(map[string]any)
@@ -263,7 +262,7 @@ func GetStockPricesAlpaca(clientConfs StockDataConf, ticker, resolution string, 
 		}
 		stockData, err = GetStockPrices(originalTicker, clientConfs.PolygonAPIToken, originalResolution, startTimeMilli, endTimeMilli)
 		if err != nil {
-			fmt.Errorf("error pulling stock data from polygon\n")
+			log.Printf("error pulling stock data from polygon: %v", err)
 			return nil, err
 		}
 	} else {
@@ -277,7 +276,7 @@ func GetStockPricesAlpaca(clientConfs StockDataConf, ticker, resolution string, 
 				timeStamp := bar["t"].(string)
 				ts, tsErr := time.Parse(time.RFC3339, timeStamp)
 				if tsErr != nil {
-					fmt.Errorf("error converting timestamp to time: %w\n", tsErr)
+					log.Printf("error converting timestamp to time: %v", tsErr)
 				}
 				tsUnixMilli := ts.UnixMilli()
 				stockData[stockSymbol][tsUnixMilli] = SingleStockCandle{
@@ -782,7 +781,7 @@ func GetLinearRegressionSlope(stockPrices map[string]map[int64]SingleStockCandle
 				}
 				shortSlope, shortIntercept, err := calcLinearRegression(shortClosingPriceXValsSlice, shortClosingPriceYValsSlice)
 				if err != nil {
-					fmt.Errorf("error getting linear regression: %e", err)
+					log.Printf("error getting linear regression: %v", err)
 				}
 				if isDebug {
 					fmt.Printf("Date: %s", stockPrices[ticker][dateInt64].Timestamp)
@@ -806,7 +805,7 @@ func GetLinearRegressionSlope(stockPrices map[string]map[int64]SingleStockCandle
 				}
 				medSlope, medIntercept, err := calcLinearRegression(medClosingPriceXValsSlice, medClosingPriceYValsSlice)
 				if err != nil {
-					fmt.Errorf("error getting linear regression: %e", err)
+					log.Printf("error getting linear regression: %v", err)
 				}
 				if isDebug {
 					fmt.Printf("MedDuration linear regression intercept: %f\n", medIntercept)
@@ -827,7 +826,7 @@ func GetLinearRegressionSlope(stockPrices map[string]map[int64]SingleStockCandle
 				}
 				longSlope, longIntercept, err := calcLinearRegression(longClosingPriceXValsSlice, longClosingPriceYValsSlice)
 				if err != nil {
-					fmt.Errorf("error getting linear regression: %e", err)
+					log.Printf("error getting linear regression: %v", err)
 					return stockPrices
 				}
 				if isDebug {

--- a/pkg/portfolioToolsStructs.go
+++ b/pkg/portfolioToolsStructs.go
@@ -46,37 +46,37 @@ type HistoricalBar struct {
 }
 
 type SingleStockCandle struct {
-	Ticker                string             `json:"ticker"`
-	Close                 float64            `json:"close"`
-	High                  float64            `json:"high"`
-	Low                   float64            `json:"low"`
-	Open                  float64            `json:"open"`
-	Transactions          int64              `json:"transactions"`
-	Timestamp             time.Time          `json:"timestamp"`
-	Volume                float64            `json:"volume"`
-	WeightedVolume        float64            `json:"weighted-volume"`
-	PriceVelocity         float64            `json:"price-velocity"`
-	PriceAccel            float64            `json:"price-acceleration"`
-	AvgVolume30           float64            `json:"avg-volume-30"`
-	AvgVolume60           float64            `json:"avg-volume-60"`
-	AvgVolume90           float64            `json:"avg-volume-90"`
-	AvgVolumeRatio30      float64            `json:"avg-volume-ratio-30"`
-	AvgVolumeRatio60      float64            `json:"avg-volume-ratio-60"`
-	AvgVolumeRatio90      float64            `json:"avg-volume-ratio-90"`
-	ThirtyDaysPrices      map[string]float64 `json:"30-days-prices"`
-	SixtyDaysPrices       map[string]float64 `json:"60-days-prices"`
-	NinetyDaysPrices      map[string]float64 `json:"90-days-prices"`
-	SlopeShortDuration    float64            `json:"trade-slope"`
-	SlopeMedDuration      float64            `json:"trend-slope"`
-	SlopeLongDuration     float64            `json:"tail-slope"`
+	Ticker             string             `json:"ticker"`
+	Close              float64            `json:"close"`
+	High               float64            `json:"high"`
+	Low                float64            `json:"low"`
+	Open               float64            `json:"open"`
+	Transactions       int64              `json:"transactions"`
+	Timestamp          time.Time          `json:"timestamp"`
+	Volume             float64            `json:"volume"`
+	WeightedVolume     float64            `json:"weighted-volume"`
+	PriceVelocity      float64            `json:"price-velocity"`
+	PriceAccel         float64            `json:"price-acceleration"`
+	AvgVolume30        float64            `json:"avg-volume-30"`
+	AvgVolume60        float64            `json:"avg-volume-60"`
+	AvgVolume90        float64            `json:"avg-volume-90"`
+	AvgVolumeRatio30   float64            `json:"avg-volume-ratio-30"`
+	AvgVolumeRatio60   float64            `json:"avg-volume-ratio-60"`
+	AvgVolumeRatio90   float64            `json:"avg-volume-ratio-90"`
+	ThirtyDaysPrices   map[string]float64 `json:"30-days-prices"`
+	SixtyDaysPrices    map[string]float64 `json:"60-days-prices"`
+	NinetyDaysPrices   map[string]float64 `json:"90-days-prices"`
+	SlopeShortDuration float64            `json:"trade-slope"`
+	SlopeMedDuration   float64            `json:"trend-slope"`
+	SlopeLongDuration  float64            `json:"tail-slope"`
 	// slope validity flags — json:"-" keeps them out of JSON output
 	SlopeShortValid bool `json:"-"`
 	SlopeMedValid   bool `json:"-"`
 	SlopeLongValid  bool `json:"-"`
 	// direction labels computed from 3-day slope sign check
-	TradeDirection string `json:"trade-direction"`
-	TrendDirection string `json:"trend-direction"`
-	TailDirection  string `json:"tail-direction"`
+	TradeDirection        string             `json:"trade-direction"`
+	TrendDirection        string             `json:"trend-direction"`
+	TailDirection         string             `json:"tail-direction"`
 	RVolHigh30            float64            `json:"30-day-rvol-high"`
 	RVolLow30             float64            `json:"30-day-rvol-low"`
 	RVolHigh60            float64            `json:"60-day-rvol-high"`

--- a/pkg/rocketpoolTools.go
+++ b/pkg/rocketpoolTools.go
@@ -1,8 +1,8 @@
 package pkg
 
 type MinipoolStats struct {
-	effectivenessRate float64 `json:"effectiveness"`
-	minipoolSize      float64 `json:"minipoolsize"`
+	effectivenessRate float64
+	minipoolSize      float64
 }
 
 /*CalculateSmoothingPoolRewards estimates the rewards for the current rewards period (every 28 days) based on minipools

--- a/pkg/rocketpoolTools.go
+++ b/pkg/rocketpoolTools.go
@@ -1,8 +1,8 @@
 package pkg
 
 type MinipoolStats struct {
-	effectivenessRate float64
-	minipoolSize      float64
+	EffectivenessRate float64
+	MinipoolSize      float64
 }
 
 /*CalculateSmoothingPoolRewards estimates the rewards for the current rewards period (every 28 days) based on minipools


### PR DESCRIPTION
## Summary

- Replaces the single build-only CI job with three required status check jobs: `test`, `lint`, `build`
- **test**: runs `go vet ./...` then `go test ./...` on every push/PR
- **lint**: runs `golangci-lint` (govet, gofmt, gosimple, ineffassign, staticcheck, unused); `errcheck` disabled pending issue #7
- **build**: cross-compiles all commands including `batchStocks` and `filterJSON` which were previously missing from CI
- Adds `.golangci.yml` config
- Adds `go vet` to the Makefile `test` target so `make` matches CI locally
- Fixes all pre-existing `go vet` issues (discarded `fmt.Errorf` → `log.Printf`, unexported json-tagged fields, missing `isDebug` arg in testClient) as a prerequisite for running vet in CI

## Test Plan

- [ ] All three CI jobs pass on this PR
- [ ] `make` locally runs clean (build + vet + test)
- [ ] After merge: set branch protection on `main` requiring these three status checks + signed commits

## Notes

Once this merges and the checks have run, branch protection rules will be applied via the GitHub API to enforce signed commits and require all three jobs to pass before merge.