### PR TITLE
feat: extract NormalizeTicker to handle lower/upper/mixed-case ticker input

### DIFF
--- a/cmd/batchStocks/batchStocks.go
+++ b/cmd/batchStocks/batchStocks.go
@@ -108,8 +108,9 @@ func main() {
 	}
 
 	for _, tickerItem := range tickerArray {
+		tickerItem = pkg.NormalizeTicker(tickerItem)
 		isCrypto := false
-		if strings.HasPrefix(strings.ToUpper(tickerItem), "X:") {
+		if strings.HasPrefix(tickerItem, "X:") {
 			isCrypto = true
 		}
 		if stockDataConfig.AlpacaAPIKey != "" {
@@ -128,14 +129,14 @@ func main() {
 				resolution = "1D"
 			}
 
-			tickerData, err = pkg.GetStockPricesAlpaca(stockDataConfig, strings.ToUpper(tickerItem), resolution, startDateMilli, endDate, debug)
+			tickerData, err = pkg.GetStockPricesAlpaca(stockDataConfig, tickerItem, resolution, startDateMilli, endDate, debug)
 			if err != nil {
 				log.Fatal(err)
 			}
 		} else {
-			tickerData, err = pkg.GetStockPrices(strings.ToUpper(tickerItem), stockDataConfig.PolygonAPIToken, resolution, startDateMilli, endDate)
+			tickerData, err = pkg.GetStockPrices(tickerItem, stockDataConfig.PolygonAPIToken, resolution, startDateMilli, endDate)
 			if err != nil {
-				log.Printf("unable to get stock prices for %s", strings.ToUpper(tickerItem))
+				log.Printf("unable to get stock prices for %s", tickerItem)
 			}
 		}
 
@@ -152,7 +153,7 @@ func main() {
 		tickerData = pkg.GetSimpleSlopes(tickerData, debug)
 		tickerData = pkg.CalculateTrendDirections(tickerData, debug)
 		//tickerData = pkg.GetLinearRegressionSlope(tickerData, debug)
-		tickerStripped := strings.ToUpper(tickerItem)
+		tickerStripped := tickerItem
 		if strings.HasPrefix(tickerStripped, "X:") {
 			tickerStripped = strings.Split(tickerStripped, ":")[1]
 		}

--- a/cmd/stockClient/stockClient.go
+++ b/cmd/stockClient/stockClient.go
@@ -94,6 +94,7 @@ func main() {
 	}
 	// retrieve stock ticker's prices and store in a map
 
+	ticker = pkg.NormalizeTicker(ticker)
 	if stockDataConfig.AlpacaAPIKey != "" {
 		switch resolution {
 		case "minute", "Minute", "MINUTE", "M", "m":
@@ -109,16 +110,16 @@ func main() {
 		default:
 			resolution = "1D"
 		}
-		tickerData, err = pkg.GetStockPricesAlpaca(stockDataConfig, strings.ToUpper(ticker), resolution, startTimeMilli, endTimeMilli, debug)
+		tickerData, err = pkg.GetStockPricesAlpaca(stockDataConfig, ticker, resolution, startTimeMilli, endTimeMilli, debug)
 		if err != nil {
 			log.Printf("unable to retrieve stock data: %v", err)
 		}
-		if strings.HasPrefix(strings.ToUpper(ticker), "X:") {
+		if strings.HasPrefix(ticker, "X:") {
 			ticker = strings.Split(ticker, ":")[1]
 			fmt.Printf("ticker: %s\n", ticker)
 		}
 	} else {
-		tickerData, err = pkg.GetStockPrices(strings.ToUpper(ticker), stockDataConfig.PolygonAPIToken, resolution, startTimeMilli, endTimeMilli)
+		tickerData, err = pkg.GetStockPrices(ticker, stockDataConfig.PolygonAPIToken, resolution, startTimeMilli, endTimeMilli)
 		if err != nil {
 			log.Printf("unable to get stock prices")
 		}

--- a/pkg/TechAnalysis.go
+++ b/pkg/TechAnalysis.go
@@ -18,6 +18,12 @@ import (
 	"time"
 )
 
+// NormalizeTicker upper-cases and trims a ticker string so the CLI accepts
+// any mix of upper, lower, or mixed case input.
+func NormalizeTicker(s string) string {
+	return strings.ToUpper(strings.TrimSpace(s))
+}
+
 const DAY = 24
 const YEAR = 365.24
 const LONGDURATION = 180

--- a/pkg/TechAnalysis_test.go
+++ b/pkg/TechAnalysis_test.go
@@ -58,6 +58,29 @@ func TestCalculateDailyReturn(t *testing.T) {
 	}
 }
 
+func TestNormalizeTicker(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"all lowercase", "envx", "ENVX"},
+		{"all uppercase", "ENVX", "ENVX"},
+		{"mixed case", "eNvX", "ENVX"},
+		{"crypto lowercase prefix and symbol", "x:eth", "X:ETH"},
+		{"crypto uppercase", "X:ETH", "X:ETH"},
+		{"crypto mixed case", "X:eTh", "X:ETH"},
+		{"leading/trailing whitespace", "  aapl  ", "AAPL"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NormalizeTicker(tt.input); got != tt.want {
+				t.Errorf("NormalizeTicker(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestGetSimpleSlopes(t *testing.T) {
 	today := time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC)
 	thirtyDaysAgo := today.AddDate(0, 0, -30)    // exact target for SHORT


### PR DESCRIPTION
## Summary

- Extracted `pkg.NormalizeTicker(s string) string` from the inline `strings.ToUpper` calls scattered across both `stockClient` and `batchStocks`
- Both binaries now call `NormalizeTicker` once at the top of the ticker processing loop/block, so all downstream code works with a clean uppercase string
- Also trims leading/trailing whitespace as a bonus

## Test plan

- [x] `TestNormalizeTicker` covers 7 cases: all-lowercase, all-uppercase, mixed-case, crypto prefix lowercase (`x:eth`), crypto prefix uppercase (`X:ETH`), crypto prefix mixed (`X:eTh`), and whitespace trimming — all pass
- [x] `make` (build + vet + test) passes locally
- [x] CI build/test/lint jobs pass on the PR

Closes #19 (partial — this provides the normalization regression coverage; pipeline parity tests remain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)