### PR TITLE
chore: rename module from cmd to github.com/khrystoph/portfoliotools

### DIFF
--- a/cmd/batchStocks/batchStocks.go
+++ b/cmd/batchStocks/batchStocks.go
@@ -1,11 +1,11 @@
 package main
 
 import (
-	"github.com/khrystoph/portfoliotools/pkg"
 	"encoding/csv"
 	"encoding/json"
 	"errors"
 	"flag"
+	"github.com/khrystoph/portfoliotools/pkg"
 	"io"
 	"log"
 	"os"

--- a/cmd/batchStocks/batchStocks.go
+++ b/cmd/batchStocks/batchStocks.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"cmd/pkg"
+	"github.com/khrystoph/portfoliotools/pkg"
 	"encoding/csv"
 	"encoding/json"
 	"errors"

--- a/cmd/currentReturn/currentAnnualizedReturn.go
+++ b/cmd/currentReturn/currentAnnualizedReturn.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-	"github.com/khrystoph/portfoliotools/pkg"
 	"context"
 	"flag"
 	"fmt"
+	"github.com/khrystoph/portfoliotools/pkg"
 	"google.golang.org/appengine/log"
 	"time"
 )

--- a/cmd/currentReturn/currentAnnualizedReturn.go
+++ b/cmd/currentReturn/currentAnnualizedReturn.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"cmd/pkg"
+	"github.com/khrystoph/portfoliotools/pkg"
 	"context"
 	"flag"
 	"fmt"

--- a/cmd/filterJSON/filterJSON.go
+++ b/cmd/filterJSON/filterJSON.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"github.com/khrystoph/portfoliotools/pkg"
 	"encoding/json"
 	"flag"
+	"github.com/khrystoph/portfoliotools/pkg"
 	"log"
 	"os"
 	"strings"

--- a/cmd/filterJSON/filterJSON.go
+++ b/cmd/filterJSON/filterJSON.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"cmd/pkg"
+	"github.com/khrystoph/portfoliotools/pkg"
 	"encoding/json"
 	"flag"
 	"log"

--- a/cmd/stockClient/stockClient.go
+++ b/cmd/stockClient/stockClient.go
@@ -1,11 +1,11 @@
 package main
 
 import (
-	"github.com/khrystoph/portfoliotools/pkg"
 	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
+	"github.com/khrystoph/portfoliotools/pkg"
 	"log"
 	"os"
 	"strings"

--- a/cmd/stockClient/stockClient.go
+++ b/cmd/stockClient/stockClient.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"cmd/pkg"
+	"github.com/khrystoph/portfoliotools/pkg"
 	"encoding/json"
 	"errors"
 	"flag"

--- a/cmd/targetReturn/targetAnnualizedReturn.go
+++ b/cmd/targetReturn/targetAnnualizedReturn.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-	"github.com/khrystoph/portfoliotools/pkg"
 	"context"
 	"flag"
 	"fmt"
+	"github.com/khrystoph/portfoliotools/pkg"
 	"google.golang.org/appengine/log"
 	"time"
 )

--- a/cmd/targetReturn/targetAnnualizedReturn.go
+++ b/cmd/targetReturn/targetAnnualizedReturn.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"cmd/pkg"
+	"github.com/khrystoph/portfoliotools/pkg"
 	"context"
 	"flag"
 	"fmt"

--- a/cmd/testClient/testClient.go
+++ b/cmd/testClient/testClient.go
@@ -1,11 +1,11 @@
 package main
 
 import (
-	"github.com/khrystoph/portfoliotools/pkg"
 	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
+	"github.com/khrystoph/portfoliotools/pkg"
 	"log"
 	"os"
 	"strings"

--- a/cmd/testClient/testClient.go
+++ b/cmd/testClient/testClient.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"cmd/pkg"
+	"github.com/khrystoph/portfoliotools/pkg"
 	"encoding/json"
 	"errors"
 	"flag"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module cmd
+module github.com/khrystoph/portfoliotools
 
 go 1.24.0
 


### PR DESCRIPTION
## Summary

- Updates `go.mod` module declaration from `cmd` to `github.com/khrystoph/portfoliotools`
- Updates the six `cmd/pkg` import paths across all `cmd/` binaries to match
- No behavior change — build and tests pass clean

## Why

Prepares for `internal/` packages (database layer, store, adapters) being added in Track A. Import paths like `cmd/internal/db` would be confusing and non-idiomatic; `github.com/khrystoph/portfoliotools/internal/db` is correct.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] CI green